### PR TITLE
Refactor instance count

### DIFF
--- a/src/lib/core/Renderer.ts
+++ b/src/lib/core/Renderer.ts
@@ -121,7 +121,7 @@ export class Renderer {
     mode: GLenum,
     first: number,
     count: number,
-    instanceCound: number
+    instanceCount: number
   ) => void
   /**
    * The WebGL2RenderingContext.drawElementsInstanced() method of the WebGL 2 API renders primitives from array data like the gl.drawElements() method. In addition, it can execute multiple instances of a set of elements.


### PR DESCRIPTION
Render class `drawArraysInstanced()` function `instanceCound` parameter refactored to `instanceCount`, aligning with `drawElementsInstanced()`