### PR TITLE
fix: typedoc config

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
+  "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["src/lib/index.ts"],
-  "out": "docs",
-  "includes": "src"
+  "out": "docs"
 }


### PR DESCRIPTION
## Issue
When running npm run docs (or the equivalent documentation generation command), the process fails with an error related to the Typedoc configuration. No documentation is produced.

## Cause
An incorrect or outdated Typedoc configuration setting is preventing Typedoc from parsing the source files properly. As a result, the doc build stops before it can successfully generate the documentation.

## Resolution
Update the typedoc.json (or tsconfig.json if embedded) to correct the relevant configuration entries.
Remove or fix any deprecated fields that conflict with Typedoc’s latest version.
Validate changes by re-running npm run docs and ensuring the documentation is generated without errors.
This PR (or commit) updates the Typedoc configuration to the correct settings so the documentation generation no longer fails.







